### PR TITLE
[Container Service] : ContainerServices.isOperationFinished url fix

### DIFF
--- a/modules/container/ContainerService.js
+++ b/modules/container/ContainerService.js
@@ -6,7 +6,7 @@ angular.module('myApp.container')
             var obj = {};
 
             obj.isOperationFinished = function (operationUrl) {
-                return $http.get(SettingServices.getLxdApiUrl() + operationUrl);
+                return $http.get(SettingServices.getLxdUrl() + operationUrl);
             };
 
 


### PR DESCRIPTION
Since operationUrl already contains "/1.0" hence SettingServices.getLxdUrl() seems more appropriate to use. Works good for me.

Awesome work by the way.